### PR TITLE
Fix migration that had wrong result level names

### DIFF
--- a/django/website/logframe/migrations/0007_auto_20160425_1155.py
+++ b/django/website/logframe/migrations/0007_auto_20160425_1155.py
@@ -10,8 +10,8 @@ def add_level_details(apps, schema_editor):
     for logframe in LogFrame.objects.all():
         ResultLevelName.objects.bulk_create([
             ResultLevelName(level_number=1, level_name="Goal", logframe=logframe),
-            ResultLevelName(level_number=2, level_name="Output", logframe=logframe),
-            ResultLevelName(level_number=3, level_name="Outcome", logframe=logframe),
+            ResultLevelName(level_number=2, level_name="Outcome", logframe=logframe),
+            ResultLevelName(level_number=3, level_name="Output", logframe=logframe),
             ResultLevelName(level_number=4, level_name="Activity", logframe=logframe)
         ])
 


### PR DESCRIPTION
Probably of limited use as this will only affect old Kashana instances