### PR TITLE
Stop redirection to login when selecting Create New Logframe

### DIFF
--- a/django/website/main/static/scss/forms.scss
+++ b/django/website/main/static/scss/forms.scss
@@ -129,6 +129,7 @@
 #logframes-switch select {
     padding-right: 1.5em;
     display: none;
+    width: 18em;
 }
 
 .pure-control-group ul {

--- a/django/website/main/templates/base.html
+++ b/django/website/main/templates/base.html
@@ -24,7 +24,7 @@
         {% block logframe_switching_form %}
         {% if request.user and request.user.is_authenticated %}
         <form id="logframes-switch" action="{% url "switch-logframes" %}" method="post">{% csrf_token %}
-            <select id="logframes-switch-select" name="logframe" onchange="this.form.submit();">
+            <select id="logframes-switch-select" name="logframe" onchange="this.form.submit();"{% if logframe_list|length == 1 and not perms.logframe.edit_logframe %} disabled="disabled"{% endif %}>
             	{% for logframe in logframe_list %}<option value="{{ logframe.id }}"{% if request.user.preferences.last_viewed_logframe == logframe %} selected="selected"{% endif %}>{{ logframe.name }}</option>{% endfor %}
             	{% if perms.logframe.edit_logframe %}
             	<option value="-1">{% trans "Create a new Logframe" %}</option>

--- a/django/website/main/templates/base.html
+++ b/django/website/main/templates/base.html
@@ -26,7 +26,9 @@
         <form id="logframes-switch" action="{% url "switch-logframes" %}" method="post">{% csrf_token %}
             <select id="logframes-switch-select" name="logframe" onchange="this.form.submit();">
             	{% for logframe in logframe_list %}<option value="{{ logframe.id }}"{% if request.user.preferences.last_viewed_logframe == logframe %} selected="selected"{% endif %}>{{ logframe.name }}</option>{% endfor %}
+            	{% if perms.logframe.edit_logframe %}
             	<option value="-1">{% trans "Create a new Logframe" %}</option>
+            	{% endif %}
 			</select>
 		</form>
 		{% endif %}


### PR DESCRIPTION
Fix an issue with people selecting the "Create New Logframe" option and being redirected to the login page. People without that permission are now unable to view the option. 