### PR TITLE
Don't load wafflejs in 404 or 500 template

### DIFF
--- a/django/website/main/templates/404.html
+++ b/django/website/main/templates/404.html
@@ -6,3 +6,4 @@
 {% trans "The page you are looking for does not appear to exist on this site." %}
 {% endblock content %}
 
+{% block wafflejs %}{% endblock %}

--- a/django/website/main/templates/500.html
+++ b/django/website/main/templates/500.html
@@ -9,3 +9,4 @@
 
 {% endblock %}
 
+{% block wafflejs %}{% endblock %}

--- a/django/website/main/templates/base.html
+++ b/django/website/main/templates/base.html
@@ -89,9 +89,11 @@
     </footer>
     </div> {# div.body #}
     {% block post_footer %}{% endblock %}
+    {% block wafflejs %}
     <script>
     {% wafflejs %}
     </script>
+    {% endblock %}
     {% if deploy_env == "staging" or deploy_env == "production" %}
     <script data-main="{{ STATIC_URL }}dist/logframe.min.js" src="{{ STATIC_URL }}js/lib/require.js"></script>
     {% else %}


### PR DESCRIPTION
This is an attempt to stop the KeyError 'request' seen when
another error causes Django to load the 500 template and that in
turn generates an error because the waffle JavaScript is being
loaded but there in no request info in the context.